### PR TITLE
Fixing naming conflict

### DIFF
--- a/_config/extensions.yml
+++ b/_config/extensions.yml
@@ -3,7 +3,7 @@ SilverStripe\Assets\File:
     - webp
 
 ---
-Name: imageoptimiserflysystemassetstore
+Name: silverstripeseoimages
 After:
   - "assetscore"
   - "assetstore"


### PR DESCRIPTION
Adding 'silverstripeseoimages' to replace 'imageoptimiserflysystemassetstore'

relates to https://github.com/mi32dogs/silverstripe-seo-images/issues/3